### PR TITLE
moved <body> tags outside of template, added mobileNavigation() to ma…

### DIFF
--- a/client/views/components/main_layout/mainLayout.es6
+++ b/client/views/components/main_layout/mainLayout.es6
@@ -9,3 +9,4 @@ Template.mainLayout.onCreated( function() {
 
 });
 
+Template.mainLayout.onRendered(function() { mobileNavigation(); });

--- a/client/views/components/main_layout/main_layout.html
+++ b/client/views/components/main_layout/main_layout.html
@@ -1,9 +1,7 @@
-
+<body onunload="" class="page-subpage page-about-us navigation-top-header" id="page-top">
+</body>
 
 <template name="mainLayout">
-
-    <body onunload="" class="page-subpage page-about-us navigation-top-header" id="page-top">
-
     <div id="outer-wrapper">
         <!-- Inner Wrapper -->
         <div id="inner-wrapper">
@@ -16,10 +14,5 @@
         </div>
         <!-- end Inner Wrapper -->
     </div>
-
-
-
-    </body>
-
 </template>
 


### PR DESCRIPTION
moved <body></body> out of mainLayout template, added mobileNavigation() call to mainLayout.onRendered()...it looks like if the site is loaded with <970px window then you get the offscreen nav you are after...well the button shows up...but media queries are going to be the easiest way to ensure the css gets adjusted as the viewport changes size (resize browser)...i think...
